### PR TITLE
Feature/31 readcommitedlock

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,17 @@
 # NEventStore.Persistence.Sql
 
+## 9.1.1
+
+- Target Framework supported: netstandard2.0, net462
+- Updated System.Data.SqlClient 4.8.5
+- Fix: NEventStore constraint failed with MySql 8.x (works with 5.7) [#487](https://github.com/NEventStore/NEventStore/issues/487)
+
+### Breaking Change
+
+- The fix for [#487](https://github.com/NEventStore/NEventStore/issues/487) changed how the `Commits` table is created for MySql 8.x:
+  to update an existing database in order to run on 8.x you need to manually update the `Commits` table schema and change the constraint of the `CommitId` column
+  from: `CommitId binary(16) NOT NULL CHECK (CommitId != 0)` to: `CommitId binary(16) NOT NULL CHECK (CommitId <> 0x00)`.
+
 ## 9.0.1 
 
 - Added documentation files to NuGet packages (improved intellisense support) [#36](https://github.com/NEventStore/NEventStore.Persistence.SQL/issues/36)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Target Framework supported: netstandard2.0, net462
 - Updated System.Data.SqlClient 4.8.5
+- Added Azure SQL support to MsSqlDialect [#31](https://github.com/NEventStore/NEventStore.Persistence.SQL/issues/31)
 - Fix: NEventStore constraint failed with MySql 8.x (works with 5.7) [#487](https://github.com/NEventStore/NEventStore/issues/487)
 
 ### Breaking Change
@@ -11,6 +12,7 @@
 - The fix for [#487](https://github.com/NEventStore/NEventStore/issues/487) changed how the `Commits` table is created for MySql 8.x:
   to update an existing database in order to run on 8.x you need to manually update the `Commits` table schema and change the constraint of the `CommitId` column
   from: `CommitId binary(16) NOT NULL CHECK (CommitId != 0)` to: `CommitId binary(16) NOT NULL CHECK (CommitId <> 0x00)`.
+- MsSqlDialects now have an `useAzureSql` parameter, if set to `true` the statement `WITH (READCOMMITTEDLOCK)` will be added to any `FROM Commits` query. 
 
 ## 9.0.1 
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ SQL Persistence Engine for NEventStore
 
 NEventStore.Persistence.Sql currently supports:
 
-- .net framework 4.6.1
+- .net framework 4.6.2
 - .net standard 2.0
-- .net 5.0
-- .net 6.0
 - MsSql
 - SqlLite
 - MySql
@@ -56,6 +54,18 @@ To build the project locally on a Windows Machine:
 - Install [Chocolatey](https://chocolatey.org/).
 - Optional: update `.\src\.nuget\NEventStore.Persistence.Sql.nuspec` file if needed (before creating relase packages).
 - Open a Powershell console in Administrative mode and run the build script `build.ps1` in the root of the repository.
+
+## How to Run Unit Tests (locally)
+
+- Install Database engines or use Docker to run them in a container (you can use the scripts in `./docker` folder).
+- Define the following environment variables:
+
+  ```
+  NEventStore.MsSql="Server=localhost,50001;Database=NEventStore;User Id=sa;Password=Password1;"
+  NEventStore.MySql="Server=localhost;Port=50003;Database=NEventStore;Uid=sa;Pwd=Password1;AutoEnlist=false;"
+  NEventStore.PostgreSql="Server=localhost;Port=50004;Database=NEventStore;Uid=sa;Pwd=Password1;Enlist=false;"
+  NEventStore.Oracle="Data Source=localhost:1521/XE;User Id=system;Password=Password1;Persist Security Info=True;"
+  ```
 
 ## How to contribute
 

--- a/docker/docker-compose.ci.linux.db.yml
+++ b/docker/docker-compose.ci.linux.db.yml
@@ -32,7 +32,7 @@ services:
   mysql:
     container_name: nesci-mysql-1
     platform: linux
-    image: mysql:5.7
+    image: mysql:8.0 #5.7
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:

--- a/docker/docker-compose.ci.windows.db.yml
+++ b/docker/docker-compose.ci.windows.db.yml
@@ -32,7 +32,7 @@ services:
   mysql:
     container_name: nesci-mysql-1
     platform: windows
-    image: mysql:5.7
+    image: mysql:8.0 #5.7
     command: --default-authentication-plugin=mysql_native_password
     restart: always
     environment:

--- a/src/NEventStore.Persistence.MsSql.Tests/NEventStore.Persistence.MsSql.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.MsSql.Tests/NEventStore.Persistence.MsSql.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NEventStore.Persistence.MsSql.Tests</AssemblyName>
@@ -14,16 +14,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NEventStore.Persistence.MsSql.Tests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/PersistenceEngineFixture.cs
@@ -1,20 +1,20 @@
 ﻿using NEventStore.Persistence.Sql.Tests;
 
-namespace NEventStore.Persistence.AcceptanceTests
-{
+namespace NEventStore.Persistence.AcceptanceTests {
     using NEventStore.Persistence.Sql;
     using NEventStore.Persistence.Sql.SqlDialects;
     using NEventStore.Serialization;
     using System.Data.SqlClient;
     using System.Transactions;
 
-    public partial class PersistenceEngineFixture
-    {
+    public partial class PersistenceEngineFixture {
+        public ISqlDialect SqlDialect { get; set; } = new MsSqlDialect();
+
         /// <summary>
         /// this mimic the current NEventStore default values which is run outside any transaction (creates a scope that
         /// suppresses any transaction)
         /// </summary>
-        public TransactionScopeOption? ScopeOption { get; set; } = null; // the old default: TransactionScopeOption.Suppress;
+        public TransactionScopeOption? ScopeOption { get; set; }  // the old default: TransactionScopeOption.Suppress;
 
         public PersistenceEngineFixture()
         {
@@ -22,7 +22,7 @@ namespace NEventStore.Persistence.AcceptanceTests
             _createPersistence = pageSize =>
                 new SqlPersistenceFactory(new EnviromentConnectionFactory("MsSql", "System.Data.SqlClient"),
                     new BinarySerializer(),
-                    new MsSqlDialect(),
+                    SqlDialect,
                     pageSize: pageSize,
                     scopeOption: ScopeOption
                     ).Build();
@@ -30,7 +30,7 @@ namespace NEventStore.Persistence.AcceptanceTests
             _createPersistence = pageSize =>
                 new SqlPersistenceFactory(new EnviromentConnectionFactory("MsSql", SqlClientFactory.Instance),
                     new BinarySerializer(),
-                    new MsSqlDialect(),
+                    SqlDialect,
                     pageSize: pageSize,
                     scopeOption: ScopeOption
                     ).Build();

--- a/src/NEventStore.Persistence.MsSql.Tests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/PersistenceEngineFixture.cs
@@ -18,7 +18,7 @@ namespace NEventStore.Persistence.AcceptanceTests
 
         public PersistenceEngineFixture()
         {
-#if NET461
+#if NET462
             _createPersistence = pageSize =>
                 new SqlPersistenceFactory(new EnviromentConnectionFactory("MsSql", "System.Data.SqlClient"),
                     new BinarySerializer(),

--- a/src/NEventStore.Persistence.MsSql.Tests/TransactionIsolationLevelTests.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/TransactionIsolationLevelTests.cs
@@ -4,7 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Transactions;
 using FluentAssertions;
-#if NET461
+#if NET462
 using NEventStore.Diagnostics;
 #endif
 using NEventStore.Persistence.AcceptanceTests.BDD;
@@ -123,7 +123,7 @@ namespace NEventStore.Persistence.AcceptanceTests
         public IsolationLevelPersistenceEngineFixture()
         {
             _recorder = new IsolationLevelRecorder();
-#if NET461
+#if NET462
             _connectionFactory = new EnviromentConnectionFactory("MsSql", "System.Data.SqlClient");
 #else
             _connectionFactory = new EnviromentConnectionFactory("MsSql", System.Data.SqlClient.SqlClientFactory.Instance);
@@ -141,7 +141,7 @@ namespace NEventStore.Persistence.AcceptanceTests
                 _persistence.Drop();
                 _persistence.Dispose();
             }
-#if NET461
+#if NET462
             _persistence = new PerformanceCounterPersistenceEngine(_createPersistence(), "tests");
 #else
             _persistence = _createPersistence();

--- a/src/NEventStore.Persistence.MsSql.Tests/WireupTests.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/WireupTests.cs
@@ -31,7 +31,7 @@ namespace NEventStore.Persistence.AcceptanceTests
         {
             _eventStore = Wireup
                 .Init()
-#if NET461
+#if NET462
                 .UsingSqlPersistence(new EnviromentConnectionFactory("MsSql", "System.Data.SqlClient"))
 #else
                 .UsingSqlPersistence(new EnviromentConnectionFactory("MsSql", System.Data.SqlClient.SqlClientFactory.Instance))

--- a/src/NEventStore.Persistence.MySql.Tests/NEventStore.Persistence.MySql.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.MySql.Tests/NEventStore.Persistence.MySql.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NEventStore.Persistence.MySql.Tests</AssemblyName>
@@ -14,17 +14,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="8.0.27" />
+    <PackageReference Include="MySql.Data" Version="8.1.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Data" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NEventStore.Persistence.MySql.Tests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.MySql.Tests/PersistenceEngineFixture.cs
@@ -11,7 +11,7 @@ namespace NEventStore.Persistence.AcceptanceTests
     {
         public PersistenceEngineFixture()
         {
-#if NET461
+#if NET462
             _createPersistence = pageSize =>
                     new SqlPersistenceFactory(
                         new EnviromentConnectionFactory("MySql", "MySql.Data.MySqlClient"),

--- a/src/NEventStore.Persistence.MySql.Tests/app.config
+++ b/src/NEventStore.Persistence.MySql.Tests/app.config
@@ -3,7 +3,7 @@
     <system.data>
         <DbProviderFactories>
             <remove invariant="MySql.Data.MySqlClient"/>
-            <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=8.0.27.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
+            <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=8.1.0.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d"/>
         </DbProviderFactories>
     </system.data>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/NEventStore.Persistence.PostgreSql.Tests/NEventStore.Persistence.PostgreSql.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.PostgreSql.Tests/NEventStore.Persistence.PostgreSql.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NEventStore.Persistence.PostgreSql.Tests</AssemblyName>
@@ -13,15 +13,15 @@
     <DefineConstants Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">NUNIT</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="6.0.0" />
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NEventStore.Persistence.PostgreSql.Tests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.PostgreSql.Tests/PersistenceEngineFixture.cs
@@ -14,7 +14,7 @@ namespace NEventStore.Persistence.AcceptanceTests
             // It will be done when creating the PostgreNpgsql6Dialect dialect
             // AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
 
-#if NET461
+#if NET462
             _createPersistence = pageSize =>
                 new SqlPersistenceFactory(
                     new EnviromentConnectionFactory("PostgreSql", "Npgsql"),

--- a/src/NEventStore.Persistence.Sql.Core.sln
+++ b/src/NEventStore.Persistence.Sql.Core.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		..\appveyor.yml = ..\appveyor.yml
+		..\build.ps1 = ..\build.ps1
 		..\Changelog.md = ..\Changelog.md
 		.nuget\NEventStore.Persistence.Sql.nuspec = .nuget\NEventStore.Persistence.Sql.nuspec
 		..\README.md = ..\README.md

--- a/src/NEventStore.Persistence.Sql.Tests/EnviromentConnectionFactory.cs
+++ b/src/NEventStore.Persistence.Sql.Tests/EnviromentConnectionFactory.cs
@@ -10,7 +10,7 @@ namespace NEventStore.Persistence.Sql.Tests
         private readonly string _envVarKey;
         private readonly DbProviderFactory _dbProviderFactory;
 
-#if NET461
+#if NET462
         public EnviromentConnectionFactory(string envDatabaseName, string providerInvariantName)
         {
             _envVarKey = string.Format("NEventStore.{0}", envDatabaseName);

--- a/src/NEventStore.Persistence.Sql.Tests/NEventStore.Persistence.Sql.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.Sql.Tests/NEventStore.Persistence.Sql.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NEventStore.Persistence.Sql.Tests</AssemblyName>
     <RootNamespace>NEventStore.Persistence.Sql.Tests</RootNamespace>

--- a/src/NEventStore.Persistence.Sql.Tests/PersistenceTests.Transactions.cs
+++ b/src/NEventStore.Persistence.Sql.Tests/PersistenceTests.Transactions.cs
@@ -557,7 +557,7 @@ namespace NEventStore.Persistence.AcceptanceTests
             ) : base(enlistInAmbientTransaction, transationIsolationLevel, completeTransaction: true)
         { }
 
-#if NET461
+#if NET462
         // some of these tests fails with a local instance of sql sever
         [Fact]
         public void should_throw_an_StorageUnavailableException()

--- a/src/NEventStore.Persistence.Sql.Tests/PersistenceTests.Transactions.cs
+++ b/src/NEventStore.Persistence.Sql.Tests/PersistenceTests.Transactions.cs
@@ -25,6 +25,10 @@ namespace NEventStore.Persistence.AcceptanceTests
     using Xunit.Should;
 #endif
 
+    // The following tests actually works well only for MsSqlServer
+    // we'll need some refactoring to have initialization work
+    // for different of kinds of databases.
+
     public enum TransactionScopeConcern
     {
         NoTransaction = 0,
@@ -319,11 +323,11 @@ namespace NEventStore.Persistence.AcceptanceTests
         public Unsupported_Multiple_Completing_TransactionScopes_When_EnlistInAmbientTransaction_is_and_IsolationLevel_is(
             TransactionScopeConcern enlistInAmbientTransaction,
             IsolationLevel transationIsolationLevel
-            ) : base(enlistInAmbientTransaction, transationIsolationLevel, true)
+            ) : base(enlistInAmbientTransaction, transationIsolationLevel, completeTransaction: true)
         { }
 
         [Fact]
-        public void should_throw_an_Exception_only_if_no_transaction_or_enlist_in_ambient_transaction_and_IsolationLevel_is_Serializable()
+        public void Should_throw_an_Exception_only_if_no_transaction_or_enlist_in_ambient_transaction_and_IsolationLevel_is_Serializable()
         {
             _thrown.Should().BeOfType<AggregateException>();
             _thrown.InnerException.Should().BeOfType<StorageException>();

--- a/src/NEventStore.Persistence.Sql/ConfigurationConnectionFactory.cs
+++ b/src/NEventStore.Persistence.Sql/ConfigurationConnectionFactory.cs
@@ -1,5 +1,5 @@
 // netstandard does not have support for DbFactoryProviders, we need a totally different way to initialize the driver
-#if NET461
+#if NET462
 namespace NEventStore.Persistence.Sql
 {
     using System;

--- a/src/NEventStore.Persistence.Sql/NEventStore.Persistence.Sql.Core.csproj
+++ b/src/NEventStore.Persistence.Sql/NEventStore.Persistence.Sql.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netstandard2.0;net461</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>NEventStore.Persistence.Sql</RootNamespace>
         <AssemblyName>NEventStore.Persistence.Sql</AssemblyName>
@@ -27,10 +27,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-        <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+        <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
         <Reference Include="System.Configuration" />
         <Reference Include="System.Transactions" />
         <Reference Include="System.Web" />

--- a/src/NEventStore.Persistence.Sql/SqlDialects/MsSqlDialect.cs
+++ b/src/NEventStore.Persistence.Sql/SqlDialects/MsSqlDialect.cs
@@ -2,78 +2,77 @@ using System.Data;
 using System.Transactions;
 using IsolationLevel = System.Data.IsolationLevel;
 
-namespace NEventStore.Persistence.Sql.SqlDialects
-{
+namespace NEventStore.Persistence.Sql.SqlDialects {
     using System;
     using System.Data.SqlClient;
 
-    public class MsSqlDialect : CommonSqlDialect
-    {
+    public class MsSqlDialect : CommonSqlDialect {
         private const int UniqueIndexViolation = 2601;
         private const int UniqueKeyViolation = 2627;
 
-        public override string InitializeStorage
-        {
+        /// <summary>
+        /// Add "WITH (READCOMMITTEDLOCK)" hint to any "FROM Commits" clause
+        /// (#31) Make MsSqlDialect compatible with AzureSql and READ COMMITTED SNAPSHOT
+        /// </summary>
+        private readonly bool _addReadCommittedLockToFromCommits;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="addReadCommittedLockToFromCommits">Add "WITH (READCOMMITTEDLOCK)" hint to any "FROM Commits" clause, can have an impact on multiple transactions scenarios</param>
+        public MsSqlDialect(bool addReadCommittedLockToFromCommits = false) {
+            _addReadCommittedLockToFromCommits = addReadCommittedLockToFromCommits;
+        }
+
+        public override string InitializeStorage {
             get { return MsSqlStatements.InitializeStorage; }
         }
 
-        public override string GetSnapshot
-        {
+        public override string GetSnapshot {
             get { return "SET ROWCOUNT 1;\n" + base.GetSnapshot.Replace("LIMIT 1;", ";"); }
         }
 
-        public override string GetCommitsFromStartingRevision
-        {
-            get { return NaturalPaging(base.GetCommitsFromStartingRevision); }
+        public override string GetCommitsFromStartingRevision {
+            get { return AddReadCommittedLockToFromCommits(NaturalPaging(base.GetCommitsFromStartingRevision)); }
         }
 
-        public override string GetCommitsFromInstant
-        {
-            get { return CommonTableExpressionPaging(base.GetCommitsFromInstant); }
+        public override string GetCommitsFromInstant {
+            get { return AddReadCommittedLockToFromCommits(CommonTableExpressionPaging(base.GetCommitsFromInstant)); }
         }
 
-        public override string GetCommitsFromToInstant
-        {
-            get { return CommonTableExpressionPaging(base.GetCommitsFromToInstant); }
+        public override string GetCommitsFromToInstant {
+            get { return AddReadCommittedLockToFromCommits(CommonTableExpressionPaging(base.GetCommitsFromToInstant)); }
         }
 
-        public override string PersistCommit
-        {
+        public override string PersistCommit {
             get { return MsSqlStatements.PersistCommits; }
         }
 
-        public override string GetCommitsFromCheckpoint
-        {
-            get { return CommonTableExpressionPaging(base.GetCommitsFromCheckpoint); }
+        public override string GetCommitsFromCheckpoint {
+            get { return AddReadCommittedLockToFromCommits(CommonTableExpressionPaging(base.GetCommitsFromCheckpoint)); }
         }
 
-        public override string GetCommitsFromToCheckpoint
-        {
-            get { return CommonTableExpressionPaging(base.GetCommitsFromToCheckpoint); }
+        public override string GetCommitsFromToCheckpoint {
+            get { return AddReadCommittedLockToFromCommits(CommonTableExpressionPaging(base.GetCommitsFromToCheckpoint)); }
         }
 
-        public override string GetCommitsFromBucketAndCheckpoint
-        {
-            get { return CommonTableExpressionPaging(base.GetCommitsFromBucketAndCheckpoint); }
+        public override string GetCommitsFromBucketAndCheckpoint {
+            get { return AddReadCommittedLockToFromCommits(CommonTableExpressionPaging(base.GetCommitsFromBucketAndCheckpoint)); }
         }
 
-        public override string GetCommitsFromToBucketAndCheckpoint
-        {
-            get { return CommonTableExpressionPaging(base.GetCommitsFromToBucketAndCheckpoint); }
+        public override string GetCommitsFromToBucketAndCheckpoint {
+            get { return AddReadCommittedLockToFromCommits(CommonTableExpressionPaging(base.GetCommitsFromToBucketAndCheckpoint)); }
         }
 
-        public override string GetStreamsRequiringSnapshots
-        {
+        public override string GetStreamsRequiringSnapshots {
             get { return NaturalPaging(base.GetStreamsRequiringSnapshots); }
         }
 
-        private static string NaturalPaging(string query)
-        {
+        private static string NaturalPaging(string query) {
             return "SET ROWCOUNT @Limit;\n" + RemovePaging(query);
         }
 
-        private static string CommonTableExpressionPaging(string query)
-        {
+        private static string CommonTableExpressionPaging(string query) {
             query = RemovePaging(query);
             int orderByIndex = query.IndexOf("ORDER BY");
             string orderBy = query.Substring(orderByIndex).Replace(";", string.Empty);
@@ -83,37 +82,45 @@ namespace NEventStore.Persistence.Sql.SqlDialects
             string from = query.Substring(fromIndex);
             string select = query.Substring(0, fromIndex);
 
-            string value = MsSqlStatements.PagedQueryFormat.FormatWith(select, orderBy, from);
-            return value;
+            return MsSqlStatements.PagedQueryFormat.FormatWith(select, orderBy, from);
         }
 
-        private static string RemovePaging(string query)
-        {
+        private static string RemovePaging(string query) {
             return query
                 .Replace("\n LIMIT @Limit OFFSET @Skip;", ";")
                 .Replace("\n LIMIT @Limit;", ";");
         }
 
-        public override bool IsDuplicate(Exception exception)
-        {
+        public override bool IsDuplicate(Exception exception) {
             var dbException = exception as SqlException;
             return dbException != null
                    && (dbException.Number == UniqueIndexViolation || dbException.Number == UniqueKeyViolation);
         }
 
-        public override IDbTransaction OpenTransaction(IDbConnection connection)
-        {
+        public override IDbTransaction OpenTransaction(IDbConnection connection) {
             if (Transaction.Current == null)
                 return connection.BeginTransaction(IsolationLevel.ReadCommitted);
 
             return base.OpenTransaction(connection);
         }
+
+        /// <summary>
+        /// (#31) Add 'WITH (READCOMMITTEDLOCK)' to all 'FROM Commits' statements
+        /// </summary>
+        /// <param name="query"></param>
+        private string AddReadCommittedLockToFromCommits(string query) {
+            if (!_addReadCommittedLockToFromCommits) {
+                return query;
+            }
+            return query.Replace("FROM Commits", "FROM Commits WITH (READCOMMITTEDLOCK)");
+        }
     }
 
-    public class MsSql2005Dialect : MsSqlDialect
-    {
-        public override DbType GetDateTimeDbType()
-        {
+    public class MsSql2005Dialect : MsSqlDialect {
+        public MsSql2005Dialect(bool addReadCommittedLockToFromCommits = false) : base(addReadCommittedLockToFromCommits) {
+        }
+
+        public override DbType GetDateTimeDbType() {
             return DbType.DateTime;
         }
     }

--- a/src/NEventStore.Persistence.Sql/SqlDialects/MySqlStatements.Designer.cs
+++ b/src/NEventStore.Persistence.Sql/SqlDialects/MySqlStatements.Designer.cs
@@ -19,7 +19,7 @@ namespace NEventStore.Persistence.Sql.SqlDialects {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class MySqlStatements {
@@ -68,11 +68,11 @@ namespace NEventStore.Persistence.Sql.SqlDialects {
         ///    StreamIdOriginal varchar(1000) charset utf8 NOT NULL,
         ///    StreamRevision int NOT NULL CHECK (StreamRevision &gt; 0),
         ///    Items int NOT NULL CHECK (Items &gt; 0),
-        ///    CommitId binary(16) NOT NULL CHECK (CommitId != 0),
+        ///    CommitId binary(16) NOT NULL CHECK (CommitId &lt;&gt; 0x00),
         ///    CommitSequence int NOT NULL CHECK (CommitSequence &gt; 0),
         ///    CommitStamp bigint NOT NULL,
         ///    CheckpointNumber bigint AUTO_INCREMENT,
-        ///    Headers blo [rest of string was truncated]&quot;;.
+        ///    Headers  [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string InitializeStorage {
             get {

--- a/src/NEventStore.Persistence.Sql/SqlDialects/MySqlStatements.resx
+++ b/src/NEventStore.Persistence.Sql/SqlDialects/MySqlStatements.resx
@@ -125,7 +125,7 @@
     StreamIdOriginal varchar(1000) charset utf8 NOT NULL,
     StreamRevision int NOT NULL CHECK (StreamRevision &gt; 0),
     Items int NOT NULL CHECK (Items &gt; 0),
-    CommitId binary(16) NOT NULL CHECK (CommitId != 0),
+    CommitId binary(16) NOT NULL CHECK (CommitId &lt;&gt; 0x00),
     CommitSequence int NOT NULL CHECK (CommitSequence &gt; 0),
     CommitStamp bigint NOT NULL,
     CheckpointNumber bigint AUTO_INCREMENT,

--- a/src/NEventStore.Persistence.Sql/SqlPersistenceFactory.cs
+++ b/src/NEventStore.Persistence.Sql/SqlPersistenceFactory.cs
@@ -11,7 +11,7 @@ namespace NEventStore.Persistence.Sql
         private const int DefaultPageSize = 128;
         private readonly TransactionScopeOption? _scopeOption;
 
-#if NET461
+#if NET462
         public SqlPersistenceFactory(
             string connectionName,
             ISerialize serializer,
@@ -60,7 +60,7 @@ namespace NEventStore.Persistence.Sql
             return new SqlPersistenceEngine(ConnectionFactory, Dialect, Serializer, PageSize, StreamIdHasher, _scopeOption);
         }
 
-#if NET461
+#if NET462
         protected static ISqlDialect ResolveDialect(ConnectionStringSettings settings)
         {
             string providerName = settings.ProviderName.ToUpperInvariant();

--- a/src/NEventStore.Persistence.Sql/SqlPersistenceWireupExtensions.cs
+++ b/src/NEventStore.Persistence.Sql/SqlPersistenceWireupExtensions.cs
@@ -7,7 +7,7 @@ namespace NEventStore
     public static class SqlPersistenceWireupExtensions
     {
         // netstandard does not have support for DbFactoryProviders, we need a totally different way to initialize the driver
-#if NET461
+#if NET462
         public static SqlPersistenceWireup UsingSqlPersistence(this Wireup wireup, string connectionName)
         {
             var factory = new ConfigurationConnectionFactory(connectionName);
@@ -29,7 +29,7 @@ namespace NEventStore
 
         public static SqlPersistenceWireup UsingSqlPersistence(this Wireup wireup, IConnectionFactory factory)
         {
-#if NET461
+#if NET462
             // init the global seetings if needed
             int timeout = 0;
             if (int.TryParse(System.Configuration.ConfigurationManager.AppSettings["NEventStore.SqlCommand.Timeout"], out timeout))

--- a/src/NEventStore.Persistence.Sql/ThreadScope.cs
+++ b/src/NEventStore.Persistence.Sql/ThreadScope.cs
@@ -11,7 +11,7 @@ namespace NEventStore.Persistence.Sql
 
     public class ThreadScope<T> : IDisposable where T : class
     {
-#if NET461
+#if NET462
         private readonly HttpContext _context = HttpContext.Current;
 #endif
 
@@ -77,7 +77,7 @@ namespace NEventStore.Persistence.Sql
 
         private T Load()
         {
-#if NET461
+#if NET462
             if (_context != null)
             {
                 return _context.Items[_threadKey] as T;
@@ -88,7 +88,7 @@ namespace NEventStore.Persistence.Sql
 
         private void Store(T value)
         {
-#if NET461
+#if NET462
             if (_context != null)
             {
                 _context.Items[_threadKey] = value;

--- a/src/NEventStore.Persistence.Sqlite.Tests/NEventStore.Persistence.Sqlite.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.Sqlite.Tests/NEventStore.Persistence.Sqlite.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NEventStore.Persistence.Sqlite.Tests</AssemblyName>
@@ -19,17 +19,17 @@
   </ItemGroup>
   -->
   <ItemGroup>
-    <PackageReference Include="System.Data.SQLite" Version="1.0.115.5" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.0" />
+    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="7.0.9" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NEventStore.Persistence.Sqlite.Tests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.Sqlite.Tests/PersistenceEngineFixture.cs
@@ -6,7 +6,7 @@
 
     public partial class PersistenceEngineFixture
     {
-#if NET461
+#if NET462
         public PersistenceEngineFixture()
         {
             _createPersistence = pageSize =>


### PR DESCRIPTION
MsSql: add support for READCOMMITTEDLOCK

still need to improve tests cause some of them involving multiple transaction will succeed and unsupported scenarios might become supported when using READCOMMITTEDLOCK.

but we need to refactor again tests initialization heavily.