### PR TITLE
Replaced System.Data.SqlClient with Microsoft.Data.SqlClient

### DIFF
--- a/src/NEventStore.Persistence.MsSql.Tests/NEventStore.Persistence.MsSql.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.MsSql.Tests/NEventStore.Persistence.MsSql.Core.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NEventStore.Persistence.MsSql.Tests/NEventStore.Persistence.MsSql.Core.Tests.csproj
+++ b/src/NEventStore.Persistence.MsSql.Tests/NEventStore.Persistence.MsSql.Core.Tests.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />

--- a/src/NEventStore.Persistence.MsSql.Tests/PersistenceEngineFixture.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/PersistenceEngineFixture.cs
@@ -5,7 +5,11 @@ namespace NEventStore.Persistence.AcceptanceTests
     using NEventStore.Persistence.Sql;
     using NEventStore.Persistence.Sql.SqlDialects;
     using NEventStore.Serialization;
+#if NET462
     using System.Data.SqlClient;
+#else
+    using Microsoft.Data.SqlClient;
+#endif
     using System.Transactions;
 
     public partial class PersistenceEngineFixture

--- a/src/NEventStore.Persistence.MsSql.Tests/TransactionIsolationLevelTests.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/TransactionIsolationLevelTests.cs
@@ -6,6 +6,7 @@ using System.Transactions;
 using FluentAssertions;
 #if NET462
 using NEventStore.Diagnostics;
+using System.Data.SqlClient;
 #endif
 using NEventStore.Persistence.AcceptanceTests.BDD;
 using NEventStore.Persistence.Sql;
@@ -18,7 +19,6 @@ using IsolationLevel = System.Data.IsolationLevel;
 #endif
 #if NUNIT
 using NUnit.Framework;
-using System.Data.SqlClient;
 #endif
 #if XUNIT
     using Xunit;
@@ -126,7 +126,7 @@ namespace NEventStore.Persistence.AcceptanceTests
 #if NET462
             _connectionFactory = new EnviromentConnectionFactory("MsSql", "System.Data.SqlClient");
 #else
-            _connectionFactory = new EnviromentConnectionFactory("MsSql", System.Data.SqlClient.SqlClientFactory.Instance);
+            _connectionFactory = new EnviromentConnectionFactory("MsSql", Microsoft.Data.SqlClient.SqlClientFactory.Instance);
 #endif
             _createPersistence = () =>
                 new SqlPersistenceFactory(_connectionFactory,

--- a/src/NEventStore.Persistence.MsSql.Tests/WireupTests.cs
+++ b/src/NEventStore.Persistence.MsSql.Tests/WireupTests.cs
@@ -10,9 +10,14 @@ namespace NEventStore.Persistence.AcceptanceTests
 #if MSTEST
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 #endif
+#if NET462
+    using System.Data.SqlClient;
+#else
+    using Microsoft.Data.SqlClient;
+#endif
 #if NUNIT
     using NUnit.Framework;
-    using System.Data.SqlClient;
+    
 #endif
 #if XUNIT
     using Xunit;
@@ -34,7 +39,7 @@ namespace NEventStore.Persistence.AcceptanceTests
 #if NET462
                 .UsingSqlPersistence(new EnviromentConnectionFactory("MsSql", "System.Data.SqlClient"))
 #else
-                .UsingSqlPersistence(new EnviromentConnectionFactory("MsSql", System.Data.SqlClient.SqlClientFactory.Instance))
+                .UsingSqlPersistence(new EnviromentConnectionFactory("MsSql", Microsoft.Data.SqlClient.SqlClientFactory.Instance))
 #endif
                 .WithDialect(new MsSqlDialect())
                 .WithStreamIdHasher(streamId =>

--- a/src/NEventStore.Persistence.Sql/NEventStore.Persistence.Sql.Core.csproj
+++ b/src/NEventStore.Persistence.Sql/NEventStore.Persistence.Sql.Core.csproj
@@ -31,6 +31,7 @@
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+        <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <Reference Include="System.Configuration" />
         <Reference Include="System.Transactions" />
         <Reference Include="System.Web" />

--- a/src/NEventStore.Persistence.Sql/NEventStore.Persistence.Sql.Core.csproj
+++ b/src/NEventStore.Persistence.Sql/NEventStore.Persistence.Sql.Core.csproj
@@ -28,7 +28,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-        <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
         <Reference Include="System.Configuration" />

--- a/src/NEventStore.Persistence.Sql/SqlDialects/MsSqlDialect.cs
+++ b/src/NEventStore.Persistence.Sql/SqlDialects/MsSqlDialect.cs
@@ -5,7 +5,11 @@ using IsolationLevel = System.Data.IsolationLevel;
 namespace NEventStore.Persistence.Sql.SqlDialects
 {
     using System;
+#if NET462
     using System.Data.SqlClient;
+#else
+    using Microsoft.Data.SqlClient;
+#endif
 
     public class MsSqlDialect : CommonSqlDialect
     {


### PR DESCRIPTION
The replaces System.Data.SqlClient with Microsoft.Data.SqlClient for non-net462 targets.

This should allow upgrades to net8 for consumers without breaking existing net462 apps as discussed here https://github.com/dotnet/SqlClient/issues/1930

Resolves #40 


