### PR TITLE
Feature/issue 49

### DIFF
--- a/src/NEventStore.Persistence.Sql/DefaultEventSerializer.cs
+++ b/src/NEventStore.Persistence.Sql/DefaultEventSerializer.cs
@@ -16,6 +16,11 @@ namespace NEventStore.Persistence.Sql
             _serializer = serializer;
         }
 
+        public byte[] SerializeEventMessages(IReadOnlyList<EventMessage> eventMessages)
+        {
+            return _serializer.Serialize(eventMessages);
+        }
+
         public ICollection<EventMessage> DeserializeEventMessages(byte[] input, string bucketId, string streamId,
             int streamRevision, Guid commitId,
             int commitSequence, DateTime commitStamp, long checkpoint, IReadOnlyDictionary<string, object> headers)

--- a/src/NEventStore.Persistence.Sql/ISerializeEvents.cs
+++ b/src/NEventStore.Persistence.Sql/ISerializeEvents.cs
@@ -6,7 +6,14 @@ namespace NEventStore.Persistence.Sql
     public interface ISerializeEvents
     {
         /// <summary>
-        ///     Deserializes the stream provided and reconstructs the corresponding object graph.
+        ///     Serializes the event messages.
+        /// </summary>
+        /// <param name="eventMessages">The messages to serialize.</param>
+        /// <returns>A byte array representing the serialized messages.</returns>
+        byte[] SerializeEventMessages(IReadOnlyList<EventMessage> eventMessages);
+
+        /// <summary>
+        ///     Deserializes the bytes provided and reconstructs the corresponding object graph.
         /// </summary>
         /// <param name="input">The bytes from which the object will be reconstructed.</param>
         /// <param name="bucketId">The <see cref="ICommit.BucketId" />.</param>

--- a/src/NEventStore.Persistence.Sql/SqlPersistenceEngine.cs
+++ b/src/NEventStore.Persistence.Sql/SqlPersistenceEngine.cs
@@ -324,7 +324,7 @@ namespace NEventStore.Persistence.Sql
                 cmd.AddParameter(_dialect.CommitSequence, attempt.CommitSequence);
                 cmd.AddParameter(_dialect.CommitStamp, attempt.CommitStamp, _dialect.GetDateTimeDbType());
                 cmd.AddParameter(_dialect.Headers, _serializer.Serialize(attempt.Headers));
-                _dialect.AddPayloadParamater(_connectionFactory, connection, cmd, _serializer.Serialize(attempt.Events.ToList()));
+                _dialect.AddPayloadParamater(_connectionFactory, connection, cmd, _eventSerializer.SerializeEventMessages(attempt.Events.ToList()));
                 OnPersistCommit(cmd, attempt);
                 var checkpointNumber = cmd.ExecuteScalar(_dialect.PersistCommit).ToLong();
                 return new Commit(


### PR DESCRIPTION
This pull request introduces a new method for serializing event messages in the `NEventStore.Persistence.Sql` namespace. The key changes include adding a `SerializeEventMessages` method to the `DefaultEventSerializer` class and updating the `ISerializeEvents` interface to include this method. Additionally, the `SqlPersistenceEngine` class has been updated to use the new serialization method.

### Serialization improvements:

* [`src/NEventStore.Persistence.Sql/DefaultEventSerializer.cs`](diffhunk://#diff-10edc553d8d6984d0cef085b8e9e025ce3bce9d160abe8c2c5528d8bdb30ae37R19-R23): Added the `SerializeEventMessages` method to serialize event messages using the `_serializer` instance.
* [`src/NEventStore.Persistence.Sql/ISerializeEvents.cs`](diffhunk://#diff-50177c5d87051e55450e54bdc0e156b48b4a0648f1b93a311880c0eb872762e5L9-R16): Updated the `ISerializeEvents` interface to include the `SerializeEventMessages` method for serializing event messages.

### Codebase updates:

* [`src/NEventStore.Persistence.Sql/SqlPersistenceEngine.cs`](diffhunk://#diff-52670fe160b110af0d87407a7ee067e1a300b78ab9f7954d3dc44fb407fca156L327-R327): Modified the `PersistCommit` method to use the new `SerializeEventMessages` method from `_eventSerializer` for serializing event messages.

See #49 