### PR TITLE
fix: GetStreamsToSnapshot crashing for results with more than 512 items

### DIFF
--- a/src/NEventStore.Persistence.Sql/SqlPersistenceEngine.cs
+++ b/src/NEventStore.Persistence.Sql/SqlPersistenceEngine.cs
@@ -212,7 +212,7 @@ namespace NEventStore.Persistence.Sql
 					query.AddParameter(_dialect.Threshold, maxThreshold);
 					return
 						query.ExecutePagedQuery(statement,
-							(q, s) => { }) // No next page delegate needed - @Limit parameter is handled automatically by PagedEnumerationCollection
+							(q, s) => { }) // No next page delegate needed - @Skip parameter is handled automatically by PagedEnumerationCollection
 							.Select(x => x.GetStreamToSnapshot());
 				});
 		}


### PR DESCRIPTION
The previous code were trying to set the `@StreamId` variable that is not available in the query.
The <s>`@Limit`</s> `@Skip` variable is set inside the `PagedEnumerationCollection` iterator, so there is no need for a `NextPageDelegate` callback in here.

Fixes #54 